### PR TITLE
feat: add option to use single header for destination headers

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -10,6 +10,7 @@ import (
 	"mime"
 	"net/mail"
 	"runtime"
+	"strings"
 	"time"
 )
 
@@ -92,6 +93,8 @@ type header struct {
 	cc   []*mail.Address
 	bcc  []*mail.Address
 
+	singledestheaders bool
+
 	subject string
 	datefmt string
 
@@ -158,19 +161,43 @@ func (h *header) writeTo(w io.Writer) (int, error) {
 	b.WriteString(h.from.String())
 	b.WriteString("\r\n")
 
-	// TO
-	for _, to := range h.to {
-		b.WriteString("TO: ")
-		b.WriteString(to.String())
-		b.WriteString("\r\n")
-	}
+	var length int
+	if !h.singledestheaders {
+		// TO
+		for _, to := range h.to {
+			b.WriteString("TO: ")
+			b.WriteString(to.String())
+			b.WriteString("\r\n")
+		}
 
-	// CC
-	length := len(h.cc)
-	if length > 0 {
-		for _, cc := range h.cc {
+		// CC
+		length = len(h.cc)
+		if length > 0 {
+			for _, cc := range h.cc {
+				b.WriteString("CC: ")
+				b.WriteString(cc.String())
+				b.WriteString("\r\n")
+			}
+		}
+	} else {
+		// TO
+		b.WriteString("TO: ")
+		toList := []string{}
+		for _, to := range h.to {
+			toList = append(toList, to.String())
+		}
+		b.WriteString(strings.Join(toList, ","))
+		b.WriteString("\r\n")
+
+		// CC
+		length = len(h.cc)
+		if length > 0 {
 			b.WriteString("CC: ")
-			b.WriteString(cc.String())
+			ccList := []string{}
+			for _, cc := range h.cc {
+				ccList = append(ccList, cc.String())
+			}
+			b.WriteString(strings.Join(ccList, ","))
 			b.WriteString("\r\n")
 		}
 	}

--- a/msg_export.go
+++ b/msg_export.go
@@ -140,6 +140,10 @@ func (m *Message) AddRcptBcc(bcc ...*mail.Address) {
 	m.header.bcc = append(m.header.bcc, bcc...)
 }
 
+func (m *Message) SetSingleDestinationHeaders(single bool) {
+	m.header.singledestheaders = single
+}
+
 // SetSubject sets the header of email message: 'SUBJECT'.
 func (m *Message) SetSubject(subject string) {
 	m.header.subject = subject

--- a/msg_export.go
+++ b/msg_export.go
@@ -140,8 +140,11 @@ func (m *Message) AddRcptBcc(bcc ...*mail.Address) {
 	m.header.bcc = append(m.header.bcc, bcc...)
 }
 
-func (m *Message) SetSingleDestinationHeaders(single bool) {
-	m.header.singledestheaders = single
+// SetSingleRecvAddr sets a flag which whether or not to
+// let receiver's addresses in header combined into one line.
+// see https://www.rfc-editor.org/rfc/rfc5322#section-3.6.3
+func (m *Message) SetSingleRecvAddr(single bool) {
+	m.header.singleRecvAddr = single
 }
 
 // SetSubject sets the header of email message: 'SUBJECT'.

--- a/msg_test.go
+++ b/msg_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestMessage1(t *testing.T) {
 	m := NewMessage()
+	m.SetSingleRecvAddr(true)
 	m.SetSender("alex@example.com")
 	m.SetTo("aaa-1@example.com")
 	m.AddTo("aaa-2@example.com")


### PR DESCRIPTION
Single destination headers are used in compliance with RFC 5322 (https://www.rfc-editor.org/rfc/rfc5322#section-3.6.3), which Gmail SMTP complained about. This affects the following headers:
- To
- Cc